### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       GATSBY_IS_PREVIEW: ${{ inputs.gatsby_is_preview }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache public
         id: cache-public
@@ -36,10 +36,10 @@ jobs:
 
       - name: Check if cache hit
         if: ${{ steps.cache-public.outputs.cache-hit == 'false' }}
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
-              core.setFailed('Failed to get build from cache')
+            core.setFailed('Failed to get build from cache')
 
       - name: Azure Login
         uses: azure/login@v1
@@ -51,4 +51,3 @@ jobs:
 
       - name: Upload new files
         run: az storage blob upload-batch -s public -d '$web' --account-name ${{ inputs.deployment_sa }}
-      

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,7 +19,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Read node version from `.nvmrc` file
       - id: nvmrc
@@ -79,4 +79,3 @@ jobs:
       gatsby_is_preview: false
       environment: production
     secrets: inherit
-    


### PR DESCRIPTION
This avoids some warnings:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/